### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/SlackTest.php
+++ b/tests/SlackTest.php
@@ -19,9 +19,9 @@
 namespace PhpSclack\Tests;
 
 use PhpSlack\Slack;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SlackTest extends PHPUnit_Framework_TestCase
+class SlackTest extends TestCase
 {
     /**
      * @var PhpSlack\Utils\RestApiClient


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).